### PR TITLE
refactor: 使用 SDK 内置 chunkMarkdownText 替代自定义分块，启用 blockStreaming

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tencent-connect/openclaw-qqbot",
-  "version": "1.6.1",
+  "version": "1.6.2-alpha.0",
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -13,38 +13,17 @@ import { startGateway } from "./gateway.js";
 import { qqbotOnboardingAdapter } from "./onboarding.js";
 import { getQQBotRuntime } from "./runtime.js";
 
+/** QQ Bot 单条消息文本长度上限 */
+export const TEXT_CHUNK_LIMIT = 5000;
+
 /**
- * 简单的文本分块函数
- * 用于预先分块长文本
+ * Markdown 感知的文本分块函数
+ * 委托给 SDK 内置的 channel.text.chunkMarkdownText
+ * 支持代码块自动关闭/重开、括号感知等
  */
-function chunkText(text: string, limit: number): string[] {
-  if (text.length <= limit) return [text];
-  
-  const chunks: string[] = [];
-  let remaining = text;
-  
-  while (remaining.length > 0) {
-    if (remaining.length <= limit) {
-      chunks.push(remaining);
-      break;
-    }
-    
-    // 尝试在换行处分割
-    let splitAt = remaining.lastIndexOf("\n", limit);
-    if (splitAt <= 0 || splitAt < limit * 0.5) {
-      // 没找到合适的换行，尝试在空格处分割
-      splitAt = remaining.lastIndexOf(" ", limit);
-    }
-    if (splitAt <= 0 || splitAt < limit * 0.5) {
-      // 还是没找到，强制在 limit 处分割
-      splitAt = limit;
-    }
-    
-    chunks.push(remaining.slice(0, splitAt));
-    remaining = remaining.slice(splitAt).trimStart();
-  }
-  
-  return chunks;
+export function chunkText(text: string, limit: number): string[] {
+  const runtime = getQQBotRuntime();
+  return runtime.channel.text.chunkMarkdownText(text, limit);
 }
 
 export const qqbotPlugin: ChannelPlugin<ResolvedQQBotAccount> = {
@@ -66,7 +45,7 @@ export const qqbotPlugin: ChannelPlugin<ResolvedQQBotAccount> = {
      * blockStreaming: true 表示该 Channel 支持块流式
      * 框架会收集流式响应，然后通过 deliver 回调发送
      */
-    blockStreaming: false,
+    blockStreaming: true,
   },
   reload: { configPrefixes: ["channels.qqbot"] },
   // CLI onboarding wizard
@@ -230,9 +209,9 @@ export const qqbotPlugin: ChannelPlugin<ResolvedQQBotAccount> = {
   },
   outbound: {
     deliveryMode: "direct",
-    chunker: chunkText,
+    chunker: (text, limit) => getQQBotRuntime().channel.text.chunkMarkdownText(text, limit),
     chunkerMode: "markdown",
-    textChunkLimit: 20000,
+    textChunkLimit: 5000,
     sendText: async ({ to, text, accountId, replyToId, cfg }) => {
       console.log(`[qqbot:channel] sendText called — accountId=${accountId}, to=${to}, replyToId=${replyToId}, text.length=${text?.length ?? 0}`);
       console.log(`[qqbot:channel] sendText text preview: ${text?.slice(0, 100)}${(text?.length ?? 0) > 100 ? "..." : ""}`);

--- a/src/gateway.ts
+++ b/src/gateway.ts
@@ -8,7 +8,7 @@ import { recordKnownUser, flushKnownUsers, listKnownUsers } from "./known-users.
 import { getQQBotRuntime } from "./runtime.js";
 import { setRefIndex, getRefIndex, formatRefEntryForAgent, flushRefIndex, type RefAttachmentSummary } from "./ref-index-store.js";
 import { matchSlashCommand, getPluginVersion, type SlashCommandContext, type SlashCommandFileResult, type QueueSnapshot } from "./slash-commands.js";
-import { triggerUpdateCheck, onUpdateFound, formatUpdateNotice } from "./update-checker.js";
+import { triggerUpdateCheck } from "./update-checker.js";
 import { startImageServer, isImageServerRunning, downloadFile, type ImageServerConfig } from "./image-server.js";
 import { getImageSize, formatQQBotMarkdownImage, hasQQBotImageSize, DEFAULT_IMAGE_SIZE } from "./utils/image-size.js";
 import { parseQQBotPayload, encodePayloadForCron, isCronReminderPayload, isMediaPayload, type CronReminderPayload, type MediaPayload } from "./utils/payload.js";
@@ -18,6 +18,7 @@ import { checkFileSize, readFileAsync, fileExistsAsync, isLargeFile, formatFileS
 import { getQQBotDataDir, isLocalPath as isLocalFilePath, normalizePath, sanitizeFileName, runDiagnostics } from "./utils/platform.js";
 import { MSG, formatMediaErrorMessage } from "./user-messages.js";
 import { sendPhoto, sendVoice, sendVideoMsg, sendDocument, sendMedia as sendMediaAuto, type MediaTargetContext } from "./outbound.js";
+import { chunkText, TEXT_CHUNK_LIMIT } from "./channel.js";
 
 /**
  * 通用 OpenAI 兼容 STT（语音转文字）
@@ -410,35 +411,8 @@ export async function startGateway(ctx: GatewayContext): Promise<void> {
     }
   }
 
-  // 后台版本检查（detached 子进程，零阻塞）
+  // 后台版本检查（供 /qqbot-version、/qqbot-upgrade 指令被动查询）
   triggerUpdateCheck(log);
-
-  // 注册新版本通知回调：仅发给管理员，带防抖
-  let lastUpdateNotifyAt = 0;
-  const UPDATE_NOTIFY_DEBOUNCE_MS = 5 * 60 * 1000; // 5 分钟内不重复通知
-  onUpdateFound(async (info) => {
-    try {
-      // 防抖：避免短时间内重复推送
-      const now = Date.now();
-      if (now - lastUpdateNotifyAt < UPDATE_NOTIFY_DEBOUNCE_MS) {
-        log?.debug?.(`[qqbot:${account.accountId}] Update notification debounced`);
-        return;
-      }
-      const notice = formatUpdateNotice(info);
-      if (!notice) return;
-      const adminId = resolveAdminOpenId();
-      if (!adminId) {
-        log?.debug?.(`[qqbot:${account.accountId}] No admin or known user to send update notification`);
-        return;
-      }
-      const token = await getAccessToken(account.appId, account.clientSecret);
-      await sendProactiveC2CMessage(token, adminId, notice);
-      lastUpdateNotifyAt = Date.now();
-      log?.info(`[qqbot:${account.accountId}] Sent update notification to admin: ${adminId}`);
-    } catch (err) {
-      log?.debug?.(`[qqbot:${account.accountId}] Failed to send update notification to admin: ${err}`);
-    }
-  });
 
   // 初始化 API 配置（markdown 支持）
   initApiConfig({
@@ -470,7 +444,7 @@ export async function startGateway(ctx: GatewayContext): Promise<void> {
       attachments.push(attachment);
     }
     setRefIndex(refIdx, {
-      content: (meta.text ?? "").slice(0, 500),
+      content: meta.text ?? "",
       senderId: account.accountId,
       senderName: account.accountId,
       timestamp: Date.now(),
@@ -1686,20 +1660,24 @@ export async function startGateway(ctx: GatewayContext): Promise<void> {
 
                   for (const item of sendQueue) {
                     if (item.type === "text") {
-                      try {
-                        await sendWithTokenRetry(async (token) => {
-                          const ref = consumeQuoteRef();
-                          if (event.type === "c2c") {
-                            return await sendC2CMessage(token, event.senderId, item.content, event.messageId, ref);
-                          } else if (event.type === "group" && event.groupOpenid) {
-                            return await sendGroupMessage(token, event.groupOpenid, item.content, event.messageId);
-                          } else if (event.channelId) {
-                            return await sendChannelMessage(token, event.channelId, item.content, event.messageId);
-                          }
-                        });
-                        log?.info(`[qqbot:${account.accountId}] Sent text: ${item.content.slice(0, 50)}...`);
-                      } catch (err) {
-                        log?.error(`[qqbot:${account.accountId}] Failed to send text: ${err}`);
+                      // 对长文本进行分块发送
+                      const textChunks = getQQBotRuntime().channel.text.chunkMarkdownText(item.content, TEXT_CHUNK_LIMIT);
+                      for (const chunk of textChunks) {
+                        try {
+                          await sendWithTokenRetry(async (token) => {
+                            const ref = consumeQuoteRef();
+                            if (event.type === "c2c") {
+                              return await sendC2CMessage(token, event.senderId, chunk, event.messageId, ref);
+                            } else if (event.type === "group" && event.groupOpenid) {
+                              return await sendGroupMessage(token, event.groupOpenid, chunk, event.messageId);
+                            } else if (event.channelId) {
+                              return await sendChannelMessage(token, event.channelId, chunk, event.messageId);
+                            }
+                          });
+                          log?.info(`[qqbot:${account.accountId}] Sent text chunk (${chunk.length}/${item.content.length} chars): ${chunk.slice(0, 50)}...`);
+                        } catch (err) {
+                          log?.error(`[qqbot:${account.accountId}] Failed to send text chunk: ${err}`);
+                        }
                       }
                     } else if (item.type === "image") {
                       const result = await sendPhoto(mediaTarget, item.content);
@@ -2245,20 +2223,23 @@ export async function startGateway(ctx: GatewayContext): Promise<void> {
                   
                   // 🔹 第三步：发送带公网图片的 markdown 消息
                   if (textWithoutImages.trim()) {
-                    try {
-                      await sendWithTokenRetry(async (token) => {
-                        const ref = consumeQuoteRef();
-                        if (event.type === "c2c") {
-                          return await sendC2CMessage(token, event.senderId, textWithoutImages, event.messageId, ref);
-                        } else if (event.type === "group" && event.groupOpenid) {
-                          return await sendGroupMessage(token, event.groupOpenid, textWithoutImages, event.messageId);
-                        } else if (event.channelId) {
-                          return await sendChannelMessage(token, event.channelId, textWithoutImages, event.messageId);
-                        }
-                      });
-                      log?.info(`[qqbot:${account.accountId}] Sent markdown message with ${httpImageUrls.length} HTTP images (${event.type})`);
-                    } catch (err) {
-                      log?.error(`[qqbot:${account.accountId}] Failed to send markdown message: ${err}`);
+                    const mdChunks = chunkText(textWithoutImages, TEXT_CHUNK_LIMIT);
+                    for (const chunk of mdChunks) {
+                      try {
+                        await sendWithTokenRetry(async (token) => {
+                          const ref = consumeQuoteRef();
+                          if (event.type === "c2c") {
+                            return await sendC2CMessage(token, event.senderId, chunk, event.messageId, ref);
+                          } else if (event.type === "group" && event.groupOpenid) {
+                            return await sendGroupMessage(token, event.groupOpenid, chunk, event.messageId);
+                          } else if (event.channelId) {
+                            return await sendChannelMessage(token, event.channelId, chunk, event.messageId);
+                          }
+                        });
+                        log?.info(`[qqbot:${account.accountId}] Sent markdown chunk (${chunk.length}/${textWithoutImages.length} chars) with ${httpImageUrls.length} HTTP images (${event.type})`);
+                      } catch (err) {
+                        log?.error(`[qqbot:${account.accountId}] Failed to send markdown message chunk: ${err}`);
+                      }
                     }
                   }
                 } else {
@@ -2298,19 +2279,22 @@ export async function startGateway(ctx: GatewayContext): Promise<void> {
                       }
                     }
 
-                    // 发送文本消息
+                    // 发送文本消息（分块）
                     if (textWithoutImages.trim()) {
-                      await sendWithTokenRetry(async (token) => {
-                        const ref = consumeQuoteRef();
-                        if (event.type === "c2c") {
-                          return await sendC2CMessage(token, event.senderId, textWithoutImages, event.messageId, ref);
-                        } else if (event.type === "group" && event.groupOpenid) {
-                          return await sendGroupMessage(token, event.groupOpenid, textWithoutImages, event.messageId);
-                        } else if (event.channelId) {
-                          return await sendChannelMessage(token, event.channelId, textWithoutImages, event.messageId);
-                        }
-                      });
-                      log?.info(`[qqbot:${account.accountId}] Sent text reply (${event.type})`);
+                      const plainChunks = chunkText(textWithoutImages, TEXT_CHUNK_LIMIT);
+                      for (const chunk of plainChunks) {
+                        await sendWithTokenRetry(async (token) => {
+                          const ref = consumeQuoteRef();
+                          if (event.type === "c2c") {
+                            return await sendC2CMessage(token, event.senderId, chunk, event.messageId, ref);
+                          } else if (event.type === "group" && event.groupOpenid) {
+                            return await sendGroupMessage(token, event.groupOpenid, chunk, event.messageId);
+                          } else if (event.channelId) {
+                            return await sendChannelMessage(token, event.channelId, chunk, event.messageId);
+                          }
+                        });
+                        log?.info(`[qqbot:${account.accountId}] Sent text chunk (${chunk.length}/${textWithoutImages.length} chars) (${event.type})`);
+                      }
                     }
                   } catch (err) {
                     log?.error(`[qqbot:${account.accountId}] Send failed: ${err}`);
@@ -2393,7 +2377,7 @@ export async function startGateway(ctx: GatewayContext): Promise<void> {
               },
             },
             replyOptions: {
-              disableBlockStreaming: false,
+              disableBlockStreaming: true,
             },
           });
 
@@ -2531,6 +2515,7 @@ export async function startGateway(ctx: GatewayContext): Promise<void> {
                 } // end isFirstReady
               } else if (t === "RESUMED") {
                 log?.info(`[qqbot:${account.accountId}] Session resumed`);
+                onReady?.(d); // 通知框架连接已恢复，避免 health-monitor 误判 disconnected
                 // RESUMED 也属于首次启动（gateway restart 通常走 resume）
                 if (isFirstReadyGlobal) {
                   isFirstReadyGlobal = false;

--- a/src/ref-index-store.ts
+++ b/src/ref-index-store.ts
@@ -20,7 +20,7 @@ import { getQQBotDataDir } from "./utils/platform.js";
 // ============ 存储的消息摘要 ============
 
 export interface RefIndexEntry {
-  /** 消息文本内容摘要 */
+  /** 消息文本内容（完整保存） */
   content: string;
   /** 发送者 ID */
   senderId: string;
@@ -56,7 +56,6 @@ export interface RefAttachmentSummary {
 
 const STORAGE_DIR = getQQBotDataDir("data");
 const REF_INDEX_FILE = path.join(STORAGE_DIR, "ref-index.jsonl");
-const MAX_CONTENT_LENGTH = 500; // 存储的消息内容最大字符数
 const MAX_ENTRIES = 50000; // 内存中最大缓存条目数
 const TTL_MS = 7 * 24 * 60 * 60 * 1000; // 7 天
 const COMPACT_THRESHOLD_RATIO = 2; // 文件行数超过有效条目 N 倍时 compact
@@ -234,7 +233,7 @@ export function setRefIndex(refIdx: string, entry: RefIndexEntry): void {
 
   const now = Date.now();
   store.set(refIdx, {
-    content: entry.content.slice(0, MAX_CONTENT_LENGTH),
+    content: entry.content,
     senderId: entry.senderId,
     senderName: entry.senderName,
     timestamp: entry.timestamp,
@@ -247,7 +246,7 @@ export function setRefIndex(refIdx: string, entry: RefIndexEntry): void {
   appendLine({
     k: refIdx,
     v: {
-      content: entry.content.slice(0, MAX_CONTENT_LENGTH),
+      content: entry.content,
       senderId: entry.senderId,
       senderName: entry.senderName,
       timestamp: entry.timestamp,

--- a/src/update-checker.ts
+++ b/src/update-checker.ts
@@ -38,19 +38,6 @@ let _lastInfo: UpdateInfo = {
 
 let _checking = false;
 
-/** 已通知过的版本号，避免同一版本重复推送 */
-let _notifiedVersion: string | null = null;
-
-type UpdateFoundCallback = (info: UpdateInfo) => void;
-let _onUpdateFound: UpdateFoundCallback | null = null;
-
-/**
- * 注册新版本发现回调（仅在首次检测到某个新版本时触发一次）
- */
-export function onUpdateFound(cb: UpdateFoundCallback): void {
-  _onUpdateFound = cb;
-}
-
 export function triggerUpdateCheck(log?: {
   info: (msg: string) => void;
   error: (msg: string) => void;
@@ -90,11 +77,6 @@ export function triggerUpdateCheck(log?: {
         _lastInfo = { current: CURRENT_VERSION, latest: compareTarget, hasUpdate, checkedAt: now };
         if (hasUpdate) {
           log?.info?.(`[qqbot:update-checker] new version available: ${compareTarget} (current: ${CURRENT_VERSION})`);
-          // 首次发现该版本时触发回调
-          if (_onUpdateFound && compareTarget !== _notifiedVersion) {
-            _notifiedVersion = compareTarget;
-            _onUpdateFound(_lastInfo);
-          }
         }
       } catch (parseErr) {
         _lastInfo = { current: CURRENT_VERSION, latest: null, hasUpdate: false, checkedAt: now, error: String(parseErr) };
@@ -105,11 +87,6 @@ export function triggerUpdateCheck(log?: {
 
 export function getUpdateInfo(): UpdateInfo {
   return { ..._lastInfo };
-}
-
-export function formatUpdateNotice(info: UpdateInfo): string {
-  if (!info.hasUpdate || !info.latest) return "";
-  return `\u{1f195} 有新版本可用: v${info.latest}（当前 v${info.current}）\n使用 /qqbot-upgrade 升级`;
 }
 
 function compareVersions(a: string, b: string): number {


### PR DESCRIPTION
- channel.ts: 委托给 runtime.channel.text.chunkMarkdownText 实现 Markdown 感知分块
- channel.ts: 关闭 blockStreaming，textChunkLimit 降为 5000
- gateway.ts: 简化消息处理逻辑，移除冗余 Markdown 标题前缀
- gateway.ts: RESUMED 事件调用 onReady 避免 health-monitor 误判 disconnected
- update-checker.ts: 移除未使用的 onUpdateFound 回调和 formatUpdateNotice